### PR TITLE
Ajusta rótulos e validações de proposta

### DIFF
--- a/gerar_proposta.py
+++ b/gerar_proposta.py
@@ -258,7 +258,7 @@ def gerar_proposta_docx(
         dados_topo = (
             f"{proposta.company} / {proposta.cnpj} / {proposta.client_name} / "
             f"{proposta.data_criacao.strftime('%d/%m/%Y') if proposta.data_criacao else ''}\n"
-            f"Telefone: {tel_raw}  EMAIL: {proposta.email}"
+            f"Telefone: {tel_raw}  E-mail: {proposta.email}"
         )
         condicoes = (
             "CONDIÇÕES COMERCIAIS:\n"

--- a/models.py
+++ b/models.py
@@ -26,10 +26,13 @@ class ParamCategory(Enum):
 
 class ParamOption(db.Model):
     __tablename__ = "param_options"
+    __table_args__ = (
+        db.UniqueConstraint("category", "label", name="uq_param_options_category_label"),
+    )
 
     id            = db.Column(db.Integer, primary_key=True)
     category      = db.Column(db.Enum(ParamCategory), nullable=False)
-    label         = db.Column(db.String(120), nullable=False, unique=True)
+    label         = db.Column(db.String(120), nullable=False)
 
     created_by_id = db.Column(db.Integer, db.ForeignKey('users.id'))
     created_by    = db.relationship(
@@ -48,7 +51,7 @@ class User(db.Model):
     usuario       = db.Column(db.String(64), unique=True, nullable=False)
     nome_completo = db.Column(db.String(128))
     senha_hash    = db.Column(db.String(200), nullable=False)
-    tipo          = db.Column(db.String(20))    # administrador | gestor | usuario
+    tipo          = db.Column(db.String(20))    # admin | gestor | usuario
     email         = db.Column(db.String(128))
 
     prox_num      = db.Column(db.Integer, default=1)

--- a/tests/test_cnpj.py
+++ b/tests/test_cnpj.py
@@ -1,0 +1,19 @@
+import unittest
+
+from forms import cnpj_valido
+
+
+class TestCNPJValido(unittest.TestCase):
+
+    def test_cnpj_valido_retorna_true_para_numero_valido(self):
+        self.assertTrue(cnpj_valido("04.252.011/0001-10"))
+
+    def test_cnpj_valido_retorna_false_para_digitos_repetidos(self):
+        self.assertFalse(cnpj_valido("11.111.111/1111-11"))
+
+    def test_cnpj_valido_retorna_false_para_digitos_verificadores_invalidos(self):
+        self.assertFalse(cnpj_valido("04.252.011/0001-11"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- corrige o rótulo de e-mail gerado no documento de proposta
- ajusta a restrição de unicidade de ParamOption e alinha o comentário do campo `tipo`
- adiciona testes unitários cobrindo cenários válidos e inválidos do `cnpj_valido`

## Testing
- python -m unittest discover -s tests -p "test_*.py"


------
https://chatgpt.com/codex/tasks/task_e_68debf8c7ba8832488f6f8d0bcb71c63