### PR TITLE
Add email delivery flow to proposal creation

### DIFF
--- a/blueprints/propostas/propostas.py
+++ b/blueprints/propostas/propostas.py
@@ -4,9 +4,13 @@
 # ===========================================================
 from zoneinfo import ZoneInfo
 from datetime import datetime, timezone
+from email.message import EmailMessage
+import re
+import smtplib
+from typing import Sequence
 
 from flask import (
-    render_template, redirect, url_for, flash,
+    current_app, render_template, redirect, url_for, flash,
     request, session, jsonify, send_file
 )
 
@@ -67,6 +71,17 @@ def _dados_colaborador():
     return usr.nome_completo or "", usr.email or ""
 
 
+def _limpar_buffers_proposta():
+    for chave in (
+        "ultima_proposta_id",
+        "equipamentos_buffer",
+        "quantidades_buffer",
+        "descontos_buffer",
+        "precos_buffer",
+    ):
+        session.pop(chave, None)
+
+
 def _fill_selects(form: ProposalForm):
     def opts(cat):
         res = [("", "-- Selecione --")]
@@ -84,21 +99,115 @@ def _fill_selects(form: ProposalForm):
     form.garantia_sys.choices  = opts(ParamCategory.GARANTIA_SYS)
 
 
-def _gerar_e_enviar_pdf(proposta, equipamentos):
+def _gerar_pdf_stream(proposta, equipamentos):
     nome_colab, email_colab = _dados_colaborador()
     cod = proposta.filename.split()[-1]
-    output = gerar_proposta_docx(
+    return gerar_proposta_docx(
         proposta, equipamentos,
         formato="pdf",
         nome_colaborador=nome_colab,
         email_colaborador=email_colab,
         proposta_cod=cod,
     )
+
+
+def _gerar_e_enviar_pdf(proposta, equipamentos):
+    output = _gerar_pdf_stream(proposta, equipamentos)
     return send_file(
         output,
         download_name=f"{proposta.filename}.pdf",
         as_attachment=False,
     )
+
+
+EMAIL_SPLIT_RE = re.compile(r"[;,\n]+")
+
+
+def _parse_emails_list(raw: str) -> list[str]:
+    if not raw:
+        return []
+    emails: list[str] = []
+    for chunk in EMAIL_SPLIT_RE.split(raw):
+        addr = chunk.strip()
+        if not addr:
+            continue
+        if "@" not in addr or addr.startswith("@") or addr.endswith("@"):
+            raise ValueError(f"E-mail inválido: {addr}")
+        local, _, domain = addr.partition("@")
+        if not local or "." not in domain:
+            raise ValueError(f"E-mail inválido: {addr}")
+        emails.append(addr)
+    return emails
+
+
+def _enviar_email_proposta(
+    proposta: Proposal,
+    equipamentos: Sequence[Equipment],
+    corpo_email: str,
+    cc_list: Sequence[str],
+):
+    config = current_app.config
+    host = config.get("MAIL_SERVER") or config.get("EMAIL_SMTP_SERVER")
+    if not host:
+        raise RuntimeError("Configuração MAIL_SERVER ausente para envio de e-mail.")
+
+    sender = config.get("MAIL_SENDER") or config.get("MAIL_DEFAULT_SENDER")
+    if not sender:
+        raise RuntimeError("Configuração MAIL_SENDER ausente para envio de e-mail.")
+
+    use_ssl = bool(config.get("MAIL_USE_SSL", False))
+    use_tls = bool(config.get("MAIL_USE_TLS", not use_ssl))
+    port = config.get("MAIL_PORT")
+    if not port:
+        port = 465 if use_ssl else (587 if use_tls else 25)
+
+    username = config.get("MAIL_USERNAME")
+    password = config.get("MAIL_PASSWORD")
+
+    pdf_stream = _gerar_pdf_stream(proposta, equipamentos)
+    pdf_stream.seek(0)
+    attachment = pdf_stream.read()
+
+    msg = EmailMessage()
+    msg["Subject"] = proposta.filename or "Proposta Comercial"
+    msg["From"] = sender
+    msg["To"] = proposta.email
+    if cc_list:
+        msg["Cc"] = ", ".join(cc_list)
+    reply_to = config.get("MAIL_REPLY_TO")
+    if reply_to:
+        msg["Reply-To"] = reply_to
+
+    corpo = corpo_email.strip() or (
+        f"Olá {proposta.client_name},\n\n"
+        "Segue em anexo a proposta comercial referente ao nosso atendimento.\n\n"
+        "Fico à disposição para dúvidas."
+    )
+    msg.set_content(corpo)
+
+    msg.add_attachment(
+        attachment,
+        maintype="application",
+        subtype="pdf",
+        filename=f"{proposta.filename}.pdf",
+    )
+
+    if use_ssl:
+        server = smtplib.SMTP_SSL(host, port)
+    else:
+        server = smtplib.SMTP(host, port)
+
+    try:
+        if use_tls and not use_ssl:
+            server.starttls()
+        if username:
+            server.login(username, password or "")
+        server.send_message(msg)
+    finally:
+        try:
+            server.quit()
+        except Exception:
+            pass
 
 # ===========================================================
 #  NOVA PROPOSTA
@@ -126,6 +235,31 @@ def nova_proposta():                    # ← NENHUM espaço antes desta linha
         email = form.email.data.strip()
         if not email_domain_has_mx(email):
             flash("Domínio de e-mail sem registro MX.", "danger")
+            return render_template(
+                "nova_proposta.html",
+                form=form,
+                equipments=equipamentos_disp,
+                form_data=request.form,
+            )
+
+        enviar_email = form.enviar_email.data
+        corpo_email = (form.email_corpo.data or "").strip()
+        enviar_copia = form.enviar_copia.data
+        cc_raw = (form.email_cc.data or "").strip() if enviar_copia else ""
+
+        if enviar_email and not corpo_email:
+            flash("Informe o conteúdo do e-mail para enviá-lo ao cliente.", "danger")
+            return render_template(
+                "nova_proposta.html",
+                form=form,
+                equipments=equipamentos_disp,
+                form_data=request.form,
+            )
+
+        try:
+            cc_list = _parse_emails_list(cc_raw) if enviar_email else []
+        except ValueError as exc:
+            flash(str(exc), "danger")
             return render_template(
                 "nova_proposta.html",
                 form=form,
@@ -169,6 +303,9 @@ def nova_proposta():                    # ← NENHUM espaço antes desta linha
             modalidade_type=form.modalidade_type.data,
             usuario_id=user.id,
             filename=filename,
+            enviar_email=enviar_email,
+            email_corpo=corpo_email if enviar_email else "",
+            email_cc=cc_raw if enviar_email else "",
         )
         db.session.add(proposta)
         db.session.commit()  # garante ID para usar nos buffers
@@ -216,6 +353,21 @@ def nova_proposta():                    # ← NENHUM espaço antes desta linha
             return redirect(url_for("propostas_bp.baixar_proposta"))
         if acao == "visualizar":
             return redirect(url_for("propostas_bp.visualizar_proposta"))
+        if acao == "enviar_email" and enviar_email:
+            try:
+                _enviar_email_proposta(proposta, eqs, corpo_email, cc_list)
+            except Exception as exc:
+                current_app.logger.exception("Falha ao enviar e-mail da proposta")
+                flash(f"Não foi possível enviar o e-mail: {exc}", "danger")
+                return render_template(
+                    "nova_proposta.html",
+                    form=form,
+                    equipments=equipamentos_disp,
+                    form_data=request.form,
+                )
+            _limpar_buffers_proposta()
+            flash("Proposta enviada por e-mail com sucesso.", "success")
+            return redirect(url_for("propostas_bp.nova_proposta"))
 
         flash("Proposta criada com sucesso.", "success")
         return redirect(url_for("propostas_bp.nova_proposta"))
@@ -250,14 +402,7 @@ def baixar_proposta():
     resp.headers["Content-Disposition"] = f'attachment; filename="{prop.filename}.pdf"'
 
     # Limpa buffers
-    for k in (
-        "ultima_proposta_id",
-        "equipamentos_buffer",
-        "quantidades_buffer",
-        "descontos_buffer",
-        "precos_buffer",
-    ):
-        session.pop(k, None)
+    _limpar_buffers_proposta()
     return resp
 
 
@@ -274,14 +419,7 @@ def visualizar_proposta():
     resp = _gerar_e_enviar_pdf(prop, eqs)
 
     # Limpa buffers
-    for k in (
-        "ultima_proposta_id",
-        "equipamentos_buffer",
-        "quantidades_buffer",
-        "descontos_buffer",
-        "precos_buffer",
-    ):
-        session.pop(k, None)
+    _limpar_buffers_proposta()
     return resp
 
 # ===========================================================
@@ -337,12 +475,19 @@ def editar_proposta(id):
             "garantia_sistema",
             "servico_type",
             "modalidade_type",
+            "enviar_email",
+            "email_corpo",
+            "email_cc",
         ]:
             valor = request.form.get(campo)
             if campo == "servico_type" and valor:
                 valor = ServicoType[valor]
-            if campo == "modalidade_type" and valor:
+            elif campo == "modalidade_type" and valor:
                 valor = ModalidadeType[valor]
+            elif campo == "enviar_email":
+                valor = valor in {"1", "true", "on", "yes"}
+            elif campo in {"email_corpo", "email_cc"} and valor is not None:
+                valor = valor.strip()
             setattr(prop, campo, valor)
 
         # --- Equipamentos: recria vínculos (sem usar .clear()) ---
@@ -394,6 +539,9 @@ def editar_proposta(id):
         garantia_sistema=prop.garantia_sistema,
         servico_type=prop.servico_type.name if prop.servico_type else "",
         modalidade_type=prop.modalidade_type.name if prop.modalidade_type else "",
+        enviar_email=prop.enviar_email,
+        email_corpo=prop.email_corpo,
+        email_cc=prop.email_cc,
         equipamentos=eq_list,
     )
 

--- a/forms.py
+++ b/forms.py
@@ -1,9 +1,11 @@
 from flask_wtf import FlaskForm
 from wtforms import (
     StringField, PasswordField, SelectField, SelectMultipleField,
-    TextAreaField, SubmitField, IntegerField
+    TextAreaField, SubmitField, IntegerField, BooleanField
 )
-from wtforms.validators import DataRequired, NumberRange, Email, ValidationError
+from wtforms.validators import (
+    DataRequired, NumberRange, Email, ValidationError, Optional
+)
 from flask_wtf.file import FileField, FileAllowed
 from models import ParamCategory, ServicoType, ModalidadeType
 
@@ -106,6 +108,11 @@ class ProposalForm(FlaskForm):
         validators=[DataRequired()],
         coerce=lambda v: ModalidadeType[v]
     )
+
+    enviar_email = BooleanField('Enviar e-mail para o cliente?')
+    email_corpo = TextAreaField('Conteúdo do e-mail', validators=[Optional()])
+    enviar_copia = BooleanField('Copiar outros e-mails?')
+    email_cc = TextAreaField('E-mails em cópia', validators=[Optional()])
 
     submit         = SubmitField('Gerar Proposta')
 

--- a/migrations/versions/6bff8c85f9f4_add_email_fields_to_proposals.py
+++ b/migrations/versions/6bff8c85f9f4_add_email_fields_to_proposals.py
@@ -1,0 +1,32 @@
+"""add email fields to proposals
+
+Revision ID: 6bff8c85f9f4
+Revises: 3c29dcdd9497
+Create Date: 2025-07-26 00:00:00.000000
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '6bff8c85f9f4'
+down_revision = '3c29dcdd9497'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('proposals', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('enviar_email', sa.Boolean(), nullable=False, server_default=sa.false()))
+        batch_op.add_column(sa.Column('email_corpo', sa.Text(), nullable=True))
+        batch_op.add_column(sa.Column('email_cc', sa.Text(), nullable=True))
+
+    with op.batch_alter_table('proposals', schema=None) as batch_op:
+        batch_op.alter_column('enviar_email', server_default=None)
+
+
+def downgrade():
+    with op.batch_alter_table('proposals', schema=None) as batch_op:
+        batch_op.drop_column('email_cc')
+        batch_op.drop_column('email_corpo')
+        batch_op.drop_column('enviar_email')

--- a/models.py
+++ b/models.py
@@ -138,9 +138,13 @@ class Proposal(db.Model):
     validade         = db.Column(db.String(256))
     garantia         = db.Column(db.String(256))
     garantia_sistema = db.Column(db.String(256))
-    
+
     servico_type    = db.Column(db.Enum(ServicoType), nullable=False, default=ServicoType.PONTO)
     modalidade_type = db.Column(db.Enum(ModalidadeType), nullable=False, default=ModalidadeType.AQUISICAO)
+
+    enviar_email    = db.Column(db.Boolean, default=False)
+    email_corpo     = db.Column(db.Text)
+    email_cc        = db.Column(db.Text)
 
     data_criacao     = db.Column(db.DateTime, default=datetime.utcnow)
     usuario_id       = db.Column(db.Integer, db.ForeignKey('users.id'), nullable=False)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = .

--- a/templates/nova_proposta.html
+++ b/templates/nova_proposta.html
@@ -29,6 +29,26 @@
     {{ form.telefone(class="form-control", id="telefone", placeholder="5521999999999") }}
   </div>
 
+  <!-- ───────────── Envio de e-mail ───────────── -->
+  <div class="form-check form-switch mb-3">
+    {{ form.enviar_email(class="form-check-input", id="enviar_email") }}
+    {{ form.enviar_email.label(class="form-check-label", for="enviar_email") }}
+  </div>
+  <div id="emailOptions" class="border rounded-3 p-3 mb-4 d-none">
+    <div class="mb-3">
+      {{ form.email_corpo.label(class="form-label", for="email_corpo") }}
+      {{ form.email_corpo(class="form-control", id="email_corpo", rows="6", placeholder="Escreva aqui a mensagem que acompanhará a proposta") }}
+    </div>
+    <div class="form-check form-switch mb-3">
+      {{ form.enviar_copia(class="form-check-input", id="enviar_copia") }}
+      {{ form.enviar_copia.label(class="form-check-label", for="enviar_copia") }}
+    </div>
+    <div class="mb-3 d-none" id="emailCcWrapper">
+      {{ form.email_cc.label(class="form-label", for="email_cc") }}
+      {{ form.email_cc(class="form-control", id="email_cc", rows="3", placeholder="Informe um e-mail por linha ou separados por vírgula ou ponto e vírgula") }}
+    </div>
+  </div>
+
   <!-- ───────────── Tipo e Modalidade ───────────── -->
   <div class="row">
     <div class="col-md-6 mb-3">
@@ -83,7 +103,7 @@
 
   <!-- ───────────── Botões ───────────── -->
   <div class="mb-3 d-flex gap-3">
-    <button id="btnBaixar" type="button" class="btn btn-primary">Baixar Proposta</button>
+    <button id="btnAcaoPrimaria" type="button" class="btn btn-primary">Baixar Proposta</button>
     <button id="btnVisualizar" type="submit" name="acao" value="visualizar"
             class="btn btn-secondary" formtarget="_blank">
       Visualizar Proposta
@@ -144,11 +164,42 @@ function normalizeTelefone(inputEl){
 
 // ===================== DOM Ready =====================
 document.addEventListener('DOMContentLoaded',()=>{
+  const formEl=document.getElementById('novaPropostaForm');
   // Outro consultor
   const usarOutro=document.getElementById('usar_outro');
   const divOutro=document.getElementById('divOutroUsuario');
   function toggleOutro(){divOutro.style.display=usarOutro.value==='sim'?'block':'none'}
   usarOutro.addEventListener('change',toggleOutro);toggleOutro();
+
+  // Envio de e-mail
+  const chkEnviarEmail=document.getElementById('enviar_email');
+  const emailOptions=document.getElementById('emailOptions');
+  const chkEnviarCopia=document.getElementById('enviar_copia');
+  const emailCcWrapper=document.getElementById('emailCcWrapper');
+  const emailCc=document.getElementById('email_cc');
+  const btnPrimario=document.getElementById('btnAcaoPrimaria');
+
+  function toggleCc(){
+    const mostrar = chkEnviarEmail.checked && chkEnviarCopia.checked;
+    emailCcWrapper.classList.toggle('d-none', !mostrar);
+  }
+
+  function toggleEmailOptions(){
+    const ativo = chkEnviarEmail.checked;
+    emailOptions.classList.toggle('d-none', !ativo);
+    if(!ativo){
+      chkEnviarCopia.checked = false;
+    }
+    toggleCc();
+    btnPrimario.textContent = ativo ? 'Enviar e-mail com a proposta' : 'Baixar Proposta';
+  }
+
+  chkEnviarEmail.addEventListener('change',()=>{
+    toggleEmailOptions();
+  });
+  chkEnviarCopia.addEventListener('change',toggleCc);
+  toggleEmailOptions();
+  toggleCc();
 
   // Selects com "Outros"
   document.querySelectorAll('.param-select').forEach(sel=>sel.addEventListener('change',function(){
@@ -239,15 +290,14 @@ document.addEventListener('DOMContentLoaded',()=>{
   }
 
   // Baixar
-  const btnBaixar=document.getElementById('btnBaixar');
   const hidden=document.getElementById('acaoHidden');
-  btnBaixar.addEventListener('click',e=>{
+  btnPrimario.addEventListener('click',e=>{
     e.preventDefault();
-    hidden.value='baixar';
+    hidden.value = chkEnviarEmail.checked ? 'enviar_email' : 'baixar';
     gerarModal.show();
     startProgress();
     shouldReload=true;
-    setTimeout(()=>document.getElementById('novaPropostaForm').submit(),150);
+    setTimeout(()=>formEl.submit(),150);
   });
 
   // Visualizar (abre em nova aba)

--- a/tests/test_email_utils.py
+++ b/tests/test_email_utils.py
@@ -1,0 +1,23 @@
+import pytest
+
+from blueprints.propostas.propostas import _parse_emails_list
+
+
+def test_parse_emails_accepts_multiple_separators():
+    raw = "cliente@empresa.com, suporte@empresa.com;financeiro@empresa.com\n vendas@empresa.com "
+    result = _parse_emails_list(raw)
+    assert result == [
+        "cliente@empresa.com",
+        "suporte@empresa.com",
+        "financeiro@empresa.com",
+        "vendas@empresa.com",
+    ]
+
+
+def test_parse_emails_ignores_empty_tokens():
+    assert _parse_emails_list("\n , ; ") == []
+
+
+def test_parse_emails_rejects_invalid_addresses():
+    with pytest.raises(ValueError):
+        _parse_emails_list("clienteempresa.com")


### PR DESCRIPTION
## Summary
- add configurable email delivery fields to the nova proposta form with dynamic UI behavior and action button changes
- persist email preferences on Proposal records and implement SMTP-based sending when requested, reusing PDF generation utilities
- create the Alembic migration and unit tests covering email list parsing helpers

## Testing
- pytest
- python app.py

------
https://chatgpt.com/codex/tasks/task_e_68debf732ee88324a3b416e308942b6f